### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,7 @@ fixtures:
     augeasproviders_sysctl: "git://github.com/simp/augeasproviders_sysctl"
     augeasproviders_core : "git://github.com/simp/augeasproviders_core"
     common: "git://github.com/simp/pupmod-simp-common"
+    simplib: "git://github.com/simp/pupmod-simp-simplib"
     iptables: "git://github.com/simp/pupmod-simp-iptables"
     nfs: "git://github.com/simp/pupmod-simp-nfs"
     stdlib: "git://github.com/simp/puppetlabs-stdlib"

--- a/build/pupmod-autofs.spec
+++ b/build/pupmod-autofs.spec
@@ -1,13 +1,13 @@
 Summary: AutoFS Puppet Module
 Name: pupmod-autofs
 Version: 4.1.0
-Release: 6
+Release: 7
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: puppetlabs-stdlib >= 3.2.0
-Requires: pupmod-concat >= 2
+Requires: pupmod-simpcat >= 2
 Requires: pupmod-nfs >= 4.1.0-8
 Requires: puppet >= 3.3.0
 Buildarch: noarch
@@ -56,6 +56,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-7
+- migration to simplib and simpcat (lib/ only)
+
 * Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-6
 - Changed puppet-server requirement to puppet
 


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-autofs`.
SIMP-604 #comment Updated `pupmod-simp-autofs`.