### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Tue Aug 09 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.2-0
 - Fixed dependency cycle between autofs and stunnel with an ugly exec.
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
 Requires: pupmod-puppetlabs-stdlib >= 3.2.0
-Requires: pupmod-simp-simpcat >= 2
+Requires: pupmod-simp-simpcat >= 6.0.0
 Requires: pupmod-simp-nfs >= 4.1.0-8
 Requires: pupmod-simp-compliance_markup
 Obsoletes: pupmod-autofs-test

--- a/manifests/map/entry.pp
+++ b/manifests/map/entry.pp
@@ -52,7 +52,7 @@ define autofs::map::entry (
 
   # This ensures that this define will only do this once.
   if !defined(File["/etc/autofs/${target}.map"]) {
-    concat_build { "autofs_${target}":
+    simpcat_build { "autofs_${target}":
       order  => ['*.map'],
       target => "/etc/autofs/${target}.map"
     }
@@ -62,12 +62,12 @@ define autofs::map::entry (
       owner     => 'root',
       group     => 'root',
       mode      => '0640',
-      subscribe => Concat_build["autofs_${target}"],
+      subscribe => Simpcat_build["autofs_${target}"],
       notify    => Service['autofs']
     }
   }
 
-  concat_fragment { "autofs_${target}+${l_name_no_slashes}.map":
+  simpcat_fragment { "autofs_${target}+${l_name_no_slashes}.map":
     content => "${l_key}\t${options}\t${location}\n"
   }
 }

--- a/manifests/map/master.pp
+++ b/manifests/map/master.pp
@@ -49,7 +49,7 @@ define autofs::map::master (
   ) {
 
   if !defined(File['/etc/auto.master']) {
-    concat_build { 'autofs_master':
+    simpcat_build { 'autofs_master':
       order  => ['*.map'],
       target => '/etc/auto.master'
     }
@@ -59,12 +59,12 @@ define autofs::map::master (
       owner     => 'root',
       group     => 'root',
       mode      => '0640',
-      subscribe => Concat_build['autofs_master'],
+      subscribe => Simpcat_build['autofs_master'],
       notify    => Service['autofs']
     }
   }
 
-  concat_fragment { "autofs_master+${name}.map":
+  simpcat_fragment { "autofs_master+${name}.map":
     content => template('autofs/auto.master.erb')
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-autofs",
-  "version": "4.1.2",
+  "version": "5.0.0",
   "author":  "simp",
   "summary": "manages autofs",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/compliance_markup",


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted autofs
