### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,9 @@
-Requires: pupmod-puppetlabs-stdlib >= 3.2.0
-Requires: pupmod-simp-simpcat >= 2
-Requires: pupmod-simp-nfs >= 4.1.0-8
-Requires: pupmod-simp-compliance_markup
 Obsoletes: pupmod-autofs-test
+Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
+Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
+Requires: pupmod-simp-compliance_markup < 2.0.0-0
+Requires: pupmod-simp-compliance_markup >= 1.0.1-0
+Requires: pupmod-simp-nfs < 5.0.0-0
+Requires: pupmod-simp-nfs >= 4.5.2-0
+Requires: pupmod-simp-simpcat < 6.0.0-0
+Requires: pupmod-simp-simpcat >= 5.0.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,29 +1,32 @@
 {
-  "name":    "simp-autofs",
-  "version": "4.1.2",
-  "author":  "simp",
+  "name": "simp-autofs",
+  "version": "4.1.3",
+  "author": "simp",
   "summary": "manages autofs",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-autofs",
+  "source": "https://github.com/simp/pupmod-simp-autofs",
   "project_page": "https://github.com/simp/pupmod-simp-autofs",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "autofs" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "autofs"
+  ],
   "dependencies": [
     {
       "name": "simp/nfs",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.5.2 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.0"
+      "version_requirement": ">= 4.9.0 < 5.0.0"
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 5.0.1 < 6.0.0"
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-autofs`
SIMP-1632 #close