### PR TITLE
(SIMP-1676) Fixes for autofs maps

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Tue Oct 11 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.3-0
+- Fixed an issue where the filenames used by 'concat' could contain '/' which
+  made them unfit for system use.
+- Also added 'audit' options to the file resources that control the 'autofs'
+  service restarts.
+
 * Tue Aug 09 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.2-0
 - Fixed dependency cycle between autofs and stunnel with an ugly exec.
 

--- a/manifests/map/master.pp
+++ b/manifests/map/master.pp
@@ -48,6 +48,8 @@ define autofs::map::master (
   $options = ''
   ) {
 
+  $_name = regsubst($name,'/','_','G')
+
   if !defined(File['/etc/auto.master']) {
     concat_build { 'autofs_master':
       order  => ['*.map'],
@@ -59,12 +61,13 @@ define autofs::map::master (
       owner     => 'root',
       group     => 'root',
       mode      => '0640',
+      audit     => 'content',
       subscribe => Concat_build['autofs_master'],
       notify    => Service['autofs']
     }
   }
 
-  concat_fragment { "autofs_master+${name}.map":
+  concat_fragment { "autofs_master+${_name}.map":
     content => template('autofs/auto.master.erb')
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-autofs",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "author": "simp",
   "summary": "manages autofs",
   "license": "Apache-2.0",


### PR DESCRIPTION
This updates the ::autofs::map::entry and ::autofs::map::master code to
work safely with the SIMP 'concat' module as well as properly ensuring
that the 'autofs' service is restarted when the content of one of the
map files is changed.

SIMP-1676 #close