### PR TITLE
(SIMP-1684) Remove pupmod-simp-sysctl

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -16,7 +16,6 @@ fixtures:
     stdlib:
       repo: "https://github.com/simp/puppetlabs-stdlib"
       branch: "simp-master"
-    sysctl: "https://github.com/simp/pupmod-simp-sysctl"
     svckill : "https://github.com/simp/pupmod-simp-svckill"
     simpcat : "https://github.com/simp/pupmod-simp-simpcat"
   symlinks:

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,3 +2,5 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-80chars-check
+--no-trailing_comma-check
+--no-empty_string_assignment-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Dec 02 2016 Nick Markowski <nmarkowski@keywcorp.com> - 5.0.1-0
+- Removed pupmod-simp-sysctl in favor of augeas-sysctl
+
 * Mon Nov 21 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0-0
 - Updated to compliance_markup version 2
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,7 +200,7 @@ class autofs (
       # Ugly exec to break the dependency cycle Service[autofs] =>
       # Service[rpcbind] => Service[nfs] => Service[stunnel] => Service[autofs]
       exec { 'refresh autofs':
-        command => 'pkill -HUP -x automount',
+        command     => 'pkill -HUP -x automount',
         refreshonly => true
       }
       Service['stunnel'] ~> Exec['refresh autofs']

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-autofs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "SIMP Team",
   "summary": "manages autofs",
   "license": "Apache-2.0",


### PR DESCRIPTION
Replaced sysctl::value with augeas 'sysctl' native type.

SIMP-1684 #comment done in autofs
SIMP-2244 #close