### PR TITLE
(SIMP-2285) Changes found when testing simp_nfs

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,6 +16,7 @@ class autofs::install {
     ensure => 'directory',
     owner  => 'root',
     group  => 'root',
-    mode   => '0640'
+    mode   => '0640',
+    purge  => true
   }
 }

--- a/manifests/ldap_auth.pp
+++ b/manifests/ldap_auth.pp
@@ -91,7 +91,7 @@ class autofs::ldap_auth (
     ensure  => 'file',
     owner   => 'root',
     group   => 'root',
-    mode    => '0640',
+    mode    => '0600',
     content => template("${module_name}/etc/ldap_auth.erb")
   }
 


### PR DESCRIPTION
* Fixed permissions on the LDAP auth configuration file
* Ensure that non-managed rules are purged from the /etc/autofs
  directory

SIMP-2285 #comment Minor fixes