### PR TITLE
(SIMP-3613) autofs: Pin concat to 3.0.0 in .fixtures.yml

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,7 +14,10 @@ fixtures:
     augeasproviders_grub :
       repo: "https://github.com/simp/augeasproviders_grub"
       branch: "simp-master"
-    concat: "https://github.com/simp/puppetlabs-concat"
+    concat:
+      # master is at 4.0.1, but we are bound to < 4.0.0 in our metadata.json
+      repo: https://github.com/simp/puppetlabs-concat
+      ref: 3.0.0
     haveged: "https://github.com/simp/puppet-haveged"
     logrotate: "https://github.com/simp/pupmod-simp-logrotate"
     pki: "https://github.com/simp/pupmod-simp-pki"


### PR DESCRIPTION
Pin concat to 3.0.0 in .fixtures.yml, as metadata.json bounds
concat to < 4.0.0.