### PR TITLE
(SIMP-4001) autofs: Allow for control of packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,48 +8,83 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
-before_script:
-  - bundle update
+sudo: false
+
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
-script:
-  - bundle exec rake test
+
 notifications:
   email: false
-rvm:
-  - 2.1.9
-env:
-  global:
-    - STRICT_VARIABLES=yes
-  matrix:
-    - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 4.10.0"
-    - PUPPET_VERSION="~> 4.9.2"
-    - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
 
-before_deploy:
-  - 'bundle exec rake metadata_lint'
-  - 'bundle exec rake clobber'
-  - 'bundle exec rake spec_clean'
-  - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-  - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-deploy:
-  - provider: puppetforge
-    user: simp
-    password:
-        secure: "dOj7Bz6UK+4VcQvxlBKhHkF1NXwBbpIE3+BbunSlf+yBJNw5DaBVgF8kND/X3oYvbh6hiNeYPVhUYUsIg5WMvHWXogl6TDYtYYzco20nsRWZ3znXCUGsgKW07K1PmZZdtXudzphkKtbtH/zfGRtxOd4uvoENlwacMClNjvZOhMbo99bXER/Urzd20KtWXqxkAKwhu0gjCtbgeMCFcT5TJ+Pb17zR46E9GoCI26DmSkzl9xcN8t0LQ3A8oEv6qadZTNP2ZevS4fUeCK3Ceu7UDdLLe4mPAm3fhHt3C3mJIT4JCbzz2FduzSUGDp/Ts+QRIf5crjDuw7XQD6ewqnMYPZEowVcZ4eYBL/qu/OTb/tJJHFy8nHUB50vS7woxp7Kp/83yMAUiZ1P98YSCsPRn+7NkE1KKKTO0SAQgdK6DqtvL6gjNp/n/vEUFDfo88xY6b6i0i9pXQqCblxjdgCkPHxfzAzBp+ySKeDu6kmbLgqoegfK7fX61mw+jbx5txR9qNdWoRfYY4BY30VeJMoooHDNf+a369Htzc7h6k88F62C3A2vfhpKNK5svDEET+FzEGtJRYo9DNWo9ojIMC8dog7U8j56CLJb4FAsGZhQvc/EuC5dTuoiZ12p3owXVqZwz3trYKsetNuivfVD6kvN0noexFDjl8ceOcTGEgcZ7YBs="
-    on:
-      tags: true
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  include:
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
+      script:
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake check:test_file
+        - bundle exec rake pkg:check_version
+        - bundle exec rake metadata_lint
+        - bundle exec rake compare_latest_tag
+        - bundle exec puppet module build
+
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
       rvm: 2.1.9
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    # This needs to be last since we have an acceptance test
+    - stage: deploy
+      rvm: 2.4.1
+      script:
+        - true
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+
+
+
+deploy:
   - provider: releases
     api_key:
-        secure: "c8FJj8AhR+Gf107JJjq98e9HzIr1PObAWXrwTtxoiFO9eEKVblTlbtTIRNbSc6IGR9mHAbBrYHkwtmxS3KYn1VG2zAK2Kz0dwinDhf46hpcPSbNpzm7k03VNu5NXRf0M8zVRJpntF1C6jX/MWeNggQHRf4dVp8m04rOiJzYfGjz6ZtaYuZkNKLtBgjPulkjqjgBB6E3QQLIuOdn7LxkLCUKomi/PfKJeHOo0nptpL4bCUIgUsHcj5CXzwTMvzdr6CbFJap+6EDn9sfcTwIPvShJA4vQ66wB+AvZluaSK71f7YzPYyp/EQzPTsP9CvdqkY5oVOwZ/8s4WH9g+PWs+t1E8v4uTfomzJLuGWppox7cfMANL9bZvqClFx7wkrvYuSZgWP4SP1c/mABviHfHRQcu83N+3F2mtHN+cGAABCxpC+5ihiDhy1HfpNwZXi0RE9unkBUtrPEICrM9RZOOxxubhItPcoOmzFJgjexySr3XFXGYNEU2TEbcFQlvQH3B9NxVdhGeQMgY7ulcE4aD5BpIyXu8TDzuE1948IugtWtRw4CvODbXYaf+7vIdvkuCY3gTCPpNtudKHpI/6fBHp/yCAvIX29jhQ7QQ+ELD2CPIdST5VJwYfaKzoAXhEcF2/2szJ2BuO7AJs9iIyX+kkQohUsLGL5YfdqYbwaZJM6zs="
+      secure: "c8FJj8AhR+Gf107JJjq98e9HzIr1PObAWXrwTtxoiFO9eEKVblTlbtTIRNbSc6IGR9mHAbBrYHkwtmxS3KYn1VG2zAK2Kz0dwinDhf46hpcPSbNpzm7k03VNu5NXRf0M8zVRJpntF1C6jX/MWeNggQHRf4dVp8m04rOiJzYfGjz6ZtaYuZkNKLtBgjPulkjqjgBB6E3QQLIuOdn7LxkLCUKomi/PfKJeHOo0nptpL4bCUIgUsHcj5CXzwTMvzdr6CbFJap+6EDn9sfcTwIPvShJA4vQ66wB+AvZluaSK71f7YzPYyp/EQzPTsP9CvdqkY5oVOwZ/8s4WH9g+PWs+t1E8v4uTfomzJLuGWppox7cfMANL9bZvqClFx7wkrvYuSZgWP4SP1c/mABviHfHRQcu83N+3F2mtHN+cGAABCxpC+5ihiDhy1HfpNwZXi0RE9unkBUtrPEICrM9RZOOxxubhItPcoOmzFJgjexySr3XFXGYNEU2TEbcFQlvQH3B9NxVdhGeQMgY7ulcE4aD5BpIyXu8TDzuE1948IugtWtRw4CvODbXYaf+7vIdvkuCY3gTCPpNtudKHpI/6fBHp/yCAvIX29jhQ7QQ+ELD2CPIdST5VJwYfaKzoAXhEcF2/2szJ2BuO7AJs9iIyX+kkQohUsLGL5YfdqYbwaZJM6zs="
     skip_cleanup: true
     on:
       tags: true
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+      condition: '($SKIP_FORGE_PUBLISH != true)'
+  - provider: puppetforge
+    user: simp
+    password:
+      secure: "dOj7Bz6UK+4VcQvxlBKhHkF1NXwBbpIE3+BbunSlf+yBJNw5DaBVgF8kND/X3oYvbh6hiNeYPVhUYUsIg5WMvHWXogl6TDYtYYzco20nsRWZ3znXCUGsgKW07K1PmZZdtXudzphkKtbtH/zfGRtxOd4uvoENlwacMClNjvZOhMbo99bXER/Urzd20KtWXqxkAKwhu0gjCtbgeMCFcT5TJ+Pb17zR46E9GoCI26DmSkzl9xcN8t0LQ3A8oEv6qadZTNP2ZevS4fUeCK3Ceu7UDdLLe4mPAm3fhHt3C3mJIT4JCbzz2FduzSUGDp/Ts+QRIf5crjDuw7XQD6ewqnMYPZEowVcZ4eYBL/qu/OTb/tJJHFy8nHUB50vS7woxp7Kp/83yMAUiZ1P98YSCsPRn+7NkE1KKKTO0SAQgdK6DqtvL6gjNp/n/vEUFDfo88xY6b6i0i9pXQqCblxjdgCkPHxfzAzBp+ySKeDu6kmbLgqoegfK7fX61mw+jbx5txR9qNdWoRfYY4BY30VeJMoooHDNf+a369Htzc7h6k88F62C3A2vfhpKNK5svDEET+FzEGtJRYo9DNWo9ojIMC8dog7U8j56CLJb4FAsGZhQvc/EuC5dTuoiZ12p3owXVqZwz3trYKsetNuivfVD6kvN0noexFDjl8ceOcTGEgcZ7YBs="
+    on:
+      tags: true
+      rvm: 2.1.9
+      condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Thu Nov 02 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.3-0
+- Allowed for control of specific versions of the packages in this
+  module with two new parameters:
+  - samba_package_ensure
+  - autofs_package_ensure
+- Support Puppet 5
+
 * Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.2-0
 - Update concat version in metadata.json
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Thu Nov 02 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.3-0
+* Thu Nov 02 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
 - Allowed for control of specific versions of the packages in this
   module with two new parameters:
   - samba_package_ensure

--- a/manifests/config/pki.pp
+++ b/manifests/config/pki.pp
@@ -31,10 +31,10 @@
 #   Path and name of the public SSL certificate
 #
 class autofs::config::pki(
-  Stdlib::Absolutepath  $app_pki_external_source  = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
-  Stdlib::Absolutepath  $app_pki_dir              = '/etc/pki/simp_apps/autofs/x509',
-  Stdlib::Absolutepath  $app_pki_cert             = "${app_pki_dir}/public/${::fqdn}.pub",
-  Stdlib::Absolutepath  $app_pki_key              = "${app_pki_dir}/private/${::fqdn}.pem"
+  Stdlib::Absolutepath $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  Stdlib::Absolutepath $app_pki_dir             = '/etc/pki/simp_apps/autofs/x509',
+  Stdlib::Absolutepath $app_pki_cert            = "${app_pki_dir}/public/${::fqdn}.pub",
+  Stdlib::Absolutepath $app_pki_key             = "${app_pki_dir}/private/${::fqdn}.pem"
 ) {
   assert_private()
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,14 @@
 #
 #   * See ``automount(8)`` for details
 #
+# @param samba_package_ensure
+#   The value to pass to the `ensure` parameter of the `samba-utils` package.
+#   Defaults to `simp_options::package_ensure` or `installed`
+#
+# @param autofs_package_ensure
+#   The value to pass to the `ensure` parameter of the `autofs` package.
+#   Defaults to `simp_options::package_ensure` or `installed`
+#
 # @param ldap
 #   Enable LDAP lookups
 #
@@ -92,28 +100,30 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class autofs (
-  String                         $master_map_name      = 'auto.master',
-  Integer                        $mount_timeout        = 600,
-  Integer                        $negative_timeout     = 60,
-  Optional[Integer]              $mount_wait           = undef,
-  Optional[Integer]              $umount_wait          = undef,
-  Boolean                        $browse_mode          = false,
-  Boolean                        $append_options       = true,
-  Enum['none','verbose','debug'] $logging              = 'none',
-  Optional[Simplib::Uri]         $ldap_uri             = undef,
-  Optional[Integer]              $ldap_timeout         = undef,
-  Optional[Integer]              $ldap_network_timeout = undef,
-  Optional[String]               $search_base          = undef,
-  Optional[String]               $map_object_class     = undef,
-  Optional[String]               $entry_object_class   = undef,
-  Optional[String]               $map_attribute        = undef,
-  Optional[String]               $entry_attribute      = undef,
-  Optional[String]               $value_attribute      = undef,
-  Optional[Integer]              $map_hash_table_size  = undef,
-  Boolean                        $use_misc_device      = true,
-  Optional[String]               $options              = undef,
-  Boolean                        $ldap                 = simplib::lookup('simp_options::ldap', { 'default_value' => false }),
-  Variant[Enum['simp'],Boolean]  $pki                  = simplib::lookup('simp_options::pki', { 'default_value' => false })
+  String                         $master_map_name       = 'auto.master',
+  Integer                        $mount_timeout         = 600,
+  Integer                        $negative_timeout      = 60,
+  Optional[Integer]              $mount_wait            = undef,
+  Optional[Integer]              $umount_wait           = undef,
+  Boolean                        $browse_mode           = false,
+  Boolean                        $append_options        = true,
+  Enum['none','verbose','debug'] $logging               = 'none',
+  Optional[Simplib::Uri]         $ldap_uri              = undef,
+  Optional[Integer]              $ldap_timeout          = undef,
+  Optional[Integer]              $ldap_network_timeout  = undef,
+  Optional[String]               $search_base           = undef,
+  Optional[String]               $map_object_class      = undef,
+  Optional[String]               $entry_object_class    = undef,
+  Optional[String]               $map_attribute         = undef,
+  Optional[String]               $entry_attribute       = undef,
+  Optional[String]               $value_attribute       = undef,
+  Optional[Integer]              $map_hash_table_size   = undef,
+  Boolean                        $use_misc_device       = true,
+  Optional[String]               $options               = undef,
+  String                         $samba_package_ensure  = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  String                         $autofs_package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  Boolean                        $ldap                  = simplib::lookup('simp_options::ldap', { 'default_value' => false }),
+  Variant[Enum['simp'],Boolean]  $pki                   = simplib::lookup('simp_options::pki', { 'default_value' => false })
 ) {
 
   contain '::autofs::install'
@@ -124,7 +134,7 @@ class autofs (
     owner   => 'root',
     group   => 'root',
     mode    => '0640',
-    content => template("${module_name}/etc/sysconfig/autofs.erb"),
+    content => template("autofs/etc/sysconfig/autofs.erb"),
     require => Class['autofs::install'],
     notify  => Class['autofs::service']
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,11 +6,13 @@ class autofs::install {
   assert_private()
 
   package { 'samba-client':
-    ensure => 'latest',
+    ensure => $::autofs::samba_package_ensure,
     before => Package['autofs']
   }
 
-  package { 'autofs': ensure  => 'latest' }
+  package { 'autofs':
+    ensure => $::autofs::autofs_package_ensure
+  }
 
   file { '/etc/autofs':
     ensure => 'directory',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-autofs",
-  "version": "6.0.3",
+  "version": "6.1.0",
   "author": "SIMP Team",
   "summary": "manages autofs",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-autofs",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "author": "SIMP Team",
   "summary": "manages autofs",
   "license": "Apache-2.0",
@@ -44,7 +44,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
- Allowed for control of specific versions of the packages in this
  module with two new parameters:
  - samba_package_ensure
  - autofs_package_ensure
- Support Puppet 5

SIMP-4001 #close