### PR TITLE
(SIMP-5309) updated $app_pki_external_source type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 6.1.2-0
+- Updated $app_pki_external_source to accept any string. This matches the
+  functionality of pki::copy.
+
 * Sat Mar 17 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.2-0
 - Updated to work with Puppet 5 and OEL
 

--- a/manifests/config/pki.pp
+++ b/manifests/config/pki.pp
@@ -31,7 +31,7 @@
 #   Path and name of the public SSL certificate
 #
 class autofs::config::pki(
-  Stdlib::Absolutepath $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  String               $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath $app_pki_dir             = '/etc/pki/simp_apps/autofs/x509',
   Stdlib::Absolutepath $app_pki_cert            = "${app_pki_dir}/public/${::fqdn}.pub",
   Stdlib::Absolutepath $app_pki_key             = "${app_pki_dir}/private/${::fqdn}.pem"


### PR DESCRIPTION
- Updated $app_pki_external_source to accept any string. This matches the
  functionality of pki::copy.

SIMP-5296 #comment Updated simp_autofs
SIMP-5309 #close