### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,7 @@
 ---
 fixtures:
   repositories:
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: "https://github.com/simp/puppetlabs-concat"
     pki: "https://github.com/simp/pupmod-simp-pki"
     simplib: "https://github.com/simp/pupmod-simp-simplib"
     stdlib: "https://github.com/simp/puppetlabs-stdlib"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Feb 14 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.3-0
+- Expanded the upper limit of the concat and stdlib Puppet module versions
+- Fixed a URL in the README.md
+
 * Thu Nov 01 2018 Jeanne Greulich <jeanner.greulich@onyxpoint.com> - 6.1.2-0
 - Static asset updates for puppet 5
 - Update badges in README.md

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-autofs",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "author": "SIMP Team",
   "summary": "manages autofs",
   "license": "Apache-2.0",
@@ -14,11 +14,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 5.0.0"
+      "version_requirement": ">= 2.2.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limit of the concat and stdlib Puppet module versions
- Fixed a URL in the README.md

SIMP-6213 #comment pupmod-simp-autofs