### PR TITLE
(SIMP-6922) concat pinned to wrong version in fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,10 +3,8 @@ fixtures:
   repositories:
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
       repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+      ref: 5.3.0
     pki: https://github.com/simp/pupmod-simp-pki
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,7 @@
 fixtures:
   repositories:
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    concat:
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 5.3.0
+    concat: https://github.com/simp/puppetlabs-concat
     pki: https://github.com/simp/pupmod-simp-pki
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib


### PR DESCRIPTION
concat was pinned to 4.1.1.  First verified worked with 5.3.0,
the version in SIMP 6.4.0, and then unpinned.