### PR TITLE
(SIMP-MAINT) autofs refinements

### DIFF
--- a/manifests/map/master.pp
+++ b/manifests/map/master.pp
@@ -43,8 +43,9 @@ define autofs::map::master (
   deprecation('autofs::map::master',
     'autofs::map::master is deprecated. Use autofs::masterfile or autofs::map instead')
 
+  include 'autofs'
+
   if $content {
-    include 'autofs'
     $_safe_name = regsubst($name, '(/|\s)', '__', 'G')
 
     file { "${autofs::master_conf_dir}/${_safe_name}.autofs":
@@ -67,9 +68,16 @@ define autofs::map::master (
       }
     }
 
+    if $map_name =~ /^\/etc\/autofs\// {
+      $_map_name = "${autofs::maps_dir}/${basename($map_name)}"
+      warning("Old configuration detected: Map file changed from ${map_name} to ${_map_name}")
+    } else {
+      $_map_name = $map_name
+    }
+
     autofs::masterfile { $name:
       mount_point => $mount_point,
-      map         => $map_name,
+      map         => $_map_name,
       map_type    => $map_type,
       map_format  => $map_format,
       options     => $options

--- a/manifests/mapfile.pp
+++ b/manifests/mapfile.pp
@@ -81,7 +81,7 @@ define autofs::mapfile (
     $_maps_dir = $maps_dir
   }
 
-  $_safe_name = regsubst($name, '(/|\s)', '__', 'G')
+  $_safe_name = regsubst(regsubst($name, '^/', ''), '(/|\s)', '__', 'G')
   $_map_file = "${_maps_dir}/${_safe_name}.map"
   file { $_map_file:
     owner   => 'root',

--- a/manifests/masterfile.pp
+++ b/manifests/masterfile.pp
@@ -105,7 +105,7 @@ define autofs::masterfile (
     'options'     => $options
   })
 
-  $_safe_name = regsubst($name, '(/|\s)', '__', 'G')
+  $_safe_name = regsubst(regsubst($name, '^/', ''), '(/|\s)', '__', 'G')
   file { "${autofs::master_conf_dir}/${_safe_name}.autofs":
     owner   => 'root',
     group   => 'root',

--- a/spec/defines/map/master_spec.rb
+++ b/spec/defines/map/master_spec.rb
@@ -9,7 +9,7 @@ describe 'autofs::map::master' do
       context  'with minimal parameters including mount_point' do
         let(:params) {{
           :mount_point => '/my/stuff',
-          :map_name    => 'bob'
+          :map_name    => '/etc/autofs.maps.simp.d/bob'
         }}
 
         it { is_expected.to compile.with_all_deps }
@@ -19,10 +19,25 @@ describe 'autofs::map::master' do
         } ) }
       end
 
+      context 'with legacy map location' do
+        let(:params) {{
+          :mount_point => '/my/stuff',
+          :map_name    => '/etc/autofs/bob'
+        }}
+
+        let(:converted_map_name) { '/etc/autofs.maps.simp.d/bob' }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_autofs__masterfile(title).with( {
+          :mount_point => params[:mount_point],
+          :map         => converted_map_name
+        } ) }
+      end
+
       context 'with a map_type specified' do
         let(:params) {{
           :mount_point => '/my/stuff',
-          :map_name    => '/bob',
+          :map_name    => '/etc/bob',
           :map_type    => 'file'
         }}
 

--- a/spec/defines/mapfile_spec.rb
+++ b/spec/defines/mapfile_spec.rb
@@ -159,7 +159,7 @@ describe 'autofs::mapfile' do
       end
 
       context 'with / in title' do
-        let(:title) { 'net/apps' }
+        let(:title) { '/net/apps' }
         let(:params) {{
           :mappings => {
             'key'      => '/net/apps',

--- a/spec/defines/masterfile_spec.rb
+++ b/spec/defines/masterfile_spec.rb
@@ -96,7 +96,7 @@ describe 'autofs::masterfile' do
 
         it { is_expected.to compile.with_all_deps }
         it 'should replace / characters' do
-          file = '/etc/auto.master.simp.d/__some__path__my_stuff.autofs'
+          file = '/etc/auto.master.simp.d/some__path__my_stuff.autofs'
           is_expected.to contain_file(file)
         end
       end


### PR DESCRIPTION
Refinements:
- In autofs::map::master, auto-convert from old maps directory to
  current maps directory and emit a warning.
  - This is to help 90% of the users who aren't doing anything
    special with this module.
- When creating filenames from autofs::masterfile and and autofs::mapfile
  resource titles that begin with '/', eliminate an initial '__' in a
  file basename.