### PR TITLE
(SIMP-MAINT) Refine safe filenames from autofs::map

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -91,7 +91,7 @@ define autofs::map(
 
   include 'autofs'
 
-  $_safe_name = regsubst($name, '(/|\s)', '__', 'G')
+  $_safe_name = regsubst(regsubst($name, '^/', ''), '(/|\s)', '__', 'G')
   $_map_filename = "${autofs::maps_dir}/${_safe_name}.map"
 
   autofs::masterfile { $_safe_name:

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -140,7 +140,7 @@ describe 'autofs::map' do
       end
 
       context 'with / in title' do
-        let(:title) { 'net/apps' }
+        let(:title) { '/net/apps' }
         let(:params) {{
           :mount_point => '/-',
           :mappings    => {


### PR DESCRIPTION
When creating filenames from autofs::map resource titles that
begin with '/', eliminate an initial '__' in a file basename.