### PR TITLE
(SIMP-9888) Ensure min stdlib is 6.6.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.18.0 < 8.0.0"
+      "version_requirement": ">= 6.6.0 < 8.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
This patch ensures the minimum puppetlabs/stdlib version is `6.6.0`.

[SIMP-9894] #close
[SIMP-9888] #comment pupmod-simp-autofs stdlib >= 6.6.0

[SIMP-9894]: https://simp-project.atlassian.net/browse/SIMP-9894
[SIMP-9888]: https://simp-project.atlassian.net/browse/SIMP-9888