### PR TITLE
(SIMP-10031) autofs Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,26 +1,24 @@
 ---
 fixtures:
   repositories:
-    augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl
-    augeasproviders_core: https://github.com/simp/augeasproviders_core
-    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    concat: https://github.com/simp/puppetlabs-concat
+    augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl.git
+    augeasproviders_core: https://github.com/simp/augeasproviders_core.git
+    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
+    concat: https://github.com/simp/puppetlabs-concat.git
     disa_stig-el7-baseline:
-      repo: https://github.com/simp/inspec-profile-disa_stig-el7
+      repo: https://github.com/simp/inspec-profile-disa_stig-el7.git
       branch: master
       target: spec/fixtures/inspec_deps/inspec_profiles/profiles
-    nfs: https://github.com/simp/pupmod-simp-nfs
-    pki: https://github.com/simp/pupmod-simp-pki
-    selinux_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-selinux_core.git
-      puppet_version: ">= 6.0.0"
-    simplib: https://github.com/simp/pupmod-simp-simplib
-    stdlib: https://github.com/simp/puppetlabs-stdlib
-    svckill: https://github.com/simp/pupmod-simp-svckill
-    systemd: https://github.com/simp/puppet-systemd
-    simp_options: https://github.com/simp/pupmod-simp-simp_options
+    nfs: https://github.com/simp/pupmod-simp-nfs.git
+    pki: https://github.com/simp/pupmod-simp-pki.git
+    selinux_core: https://github.com/simp/pupmod-puppetlabs-selinux_core.git
+    simplib: https://github.com/simp/pupmod-simp-simplib.git
+    stdlib: https://github.com/simp/puppetlabs-stdlib.git
+    svckill: https://github.com/simp/pupmod-simp-svckill.git
+    systemd: https://github.com/simp/puppet-systemd.git
+    simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     vox_selinux:
-      repo: https://github.com/simp/pupmod-voxpupuli-selinux
+      repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master
   symlinks:
     autofs: "#{source_dir}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -385,3 +385,4 @@ pup7.x:
   <<: *pup_7_x
   <<: *acceptance_base
   script:
+    - 'bundle exec rake beaker:suites[default,default]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -380,3 +380,8 @@ pup6.pe-fips-compliance:
   <<: *compliance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance,default]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,6 +20,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Add a Puppet 7 acceptance test
* Made sure all fixture URLs end in '.git', as not all private
  GitHub mirrors allow shortened URLs
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-autofs acceptance tests configured
SIMP-10031 #close

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666