### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.2.0
+- Add RockyLinux 8 support
+
 * Mon Jun 14 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.1.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/config/pki.pp
+++ b/manifests/config/pki.pp
@@ -24,8 +24,8 @@
 class autofs::config::pki(
   String               $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath $app_pki_dir             = '/etc/pki/simp_apps/autofs/x509',
-  Stdlib::Absolutepath $app_pki_cert            = "${app_pki_dir}/public/${::fqdn}.pub",
-  Stdlib::Absolutepath $app_pki_key             = "${app_pki_dir}/private/${::fqdn}.pem"
+  Stdlib::Absolutepath $app_pki_cert            = "${app_pki_dir}/public/${facts['networking']['fqdn']}.pub",
+  Stdlib::Absolutepath $app_pki_key             = "${app_pki_dir}/private/${facts['networking']['fqdn']}.pem"
 ) {
   assert_private()
 

--- a/manifests/ldap_auth.pp
+++ b/manifests/ldap_auth.pp
@@ -84,8 +84,8 @@ class autofs::ldap_auth (
   Boolean                                       $tlsrequired         = true,
   Variant[Boolean, Enum['autodetect','simple']] $authrequired        = true,
   Autofs::Authtype                              $authtype            = 'LOGIN',
-  Stdlib::Absolutepath                          $external_cert       = "/etc/pki/simp_apps/autofs/x509/public/${facts['fqdn']}.pub",
-  Stdlib::Absolutepath                          $external_key        = "/etc/pki/simp_apps/autofs/x509/private/${facts['fqdn']}.pem",
+  Stdlib::Absolutepath                          $external_cert       = "/etc/pki/simp_apps/autofs/x509/public/${facts['networking']['fqdn']}.pub",
+  Stdlib::Absolutepath                          $external_key        = "/etc/pki/simp_apps/autofs/x509/private/${facts['networking']['fqdn']}.pem",
   Optional[String]                              $clientprinc         = undef,
   Optional[Stdlib::Absolutepath]                $credentialcache     = undef
 ) {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-autofs",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "author": "SIMP Team",
   "summary": "manages autofs",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/simplib",
@@ -48,6 +48,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     }


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.