### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/spec/acceptance/suites/default/00_nfs_setup_spec.rb
+++ b/spec/acceptance/suites/default/00_nfs_setup_spec.rb
@@ -22,7 +22,6 @@ describe 'NFS setup' do
         'simp_options::firewall'    => false,
         'simp_options::kerberos'    => false,
         'simp_options::stunnel'     => false,
-        'simp_options::tcpwrappers' => false,
       }
     end
 
@@ -47,7 +46,6 @@ describe 'NFS setup' do
         'simp_options::firewall'    => false,
         'simp_options::kerberos'    => false,
         'simp_options::stunnel'     => false,
-        'simp_options::tcpwrappers' => false,
         'nfs::is_server'            => true,
       }
     end


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.